### PR TITLE
Decrement next_client_id when a player disconnects

### DIFF
--- a/server.py
+++ b/server.py
@@ -162,6 +162,7 @@ class Model(object):
         log('DISC', client.client_id, *client.client_address)
         self.clients.remove(client)
         self.send_disconnect(client)
+        self.next_client_id -= 1
         self.send_talk(client,
             '%s has disconnected from the server.' % client.nick)
     def on_chunk(self, client, p, q):


### PR DESCRIPTION
This prevents player ids from getting really large if there are a lot of 
connects/disconnects.
