### PR TITLE
Fix for #80 - Fixed collision

### DIFF
--- a/main.c
+++ b/main.c
@@ -1265,9 +1265,8 @@ int main(int argc, char **argv) {
          * At minimum 8 steps are taken (ensures gravity-like falling)
          * The MAX function chooses from all directions, so speed can be arbitrary
          *   For example: vx*dt*speed*4+1 = deltaX * [1/(pad-.1)] + 1
-         *   The 2.734375 = gravity * (minSteps -1)/minSteps^2 = 25*7/64
          */
-        int step = MAX(MAX(8,ABS(vy*speed+dy-dt*2.734375)*dt*4.2+1), MAX(ABS(vx*dt*speed*4.2),ABS(vz*dt*speed*4.2))+1);
+        int step = MAX(MAX(8,ABS(vy*speed+dy-dt*25)*dt*4.2+1), MAX(ABS(vx*dt*speed*4.2),ABS(vz*dt*speed*4.2))+1);
         float ut = dt / step;
         vx = vx * ut * speed;
         vy = vy * ut * speed;


### PR DESCRIPTION
I found a rather simple way to fix falling/walking through blocks.  It just ensures that the step count is large enough to avoid skipping over the 'pad' amount in the collide function.  It could probably look a little prettier, but I figured there was a good chance of a lot more changes happening to this function...

This is my first time submitting a pull-request, so hopefully I've done everything right...

Fixes: https://github.com/fogleman/Craft/issues/80 & https://github.com/fogleman/Craft/issues/36
