### PR TITLE
Fixed Division by 0 when minimizing window

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -187,6 +187,9 @@ int get_scale_factor() {
     int window_width, window_height;
     int buffer_width, buffer_height;
     glfwGetWindowSize(g->window, &window_width, &window_height);
+	if(window_width <= 0 || window_height <= 0){
+		return 0;
+	}
     glfwGetFramebufferSize(g->window, &buffer_width, &buffer_height);
     int result = buffer_width / window_width;
     result = MAX(1, result);


### PR DESCRIPTION
This fixes an issue where minimizing the windows in Windows 7/8 crashes the game.  The problem with the piece of code is division by 0, which the added checks prevent.  Should resolve issue #126
