### PR TITLE
added support for Visual Studio 2013

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(deps/noise)
 include_directories(deps/sqlite)
 include_directories(deps/tinycthread)
 
-if(MINGW)
+if(MINGW OR MSVC)
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
         "C:/Program Files/CURL/lib" "C:/Program Files (x86)/CURL/lib")
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH}
@@ -43,7 +43,7 @@ if(UNIX)
         ${GLFW_LIBRARIES} ${CURL_LIBRARIES})
 endif()
 
-if(MINGW)
+if(MINGW OR MSVC)
     target_link_libraries(craft ws2_32.lib glfw
         ${GLFW_LIBRARIES} ${CURL_LIBRARIES})
 endif()

--- a/src/auth.h
+++ b/src/auth.h
@@ -1,6 +1,10 @@
 #ifndef _auth_h_
 #define _auth_h_
 
+#ifdef _MSC_VER
+	#define snprintf _snprintf
+#endif
+
 int get_access_token(
     char *result, int length, char *username, char *identity_token);
 

--- a/src/client.h
+++ b/src/client.h
@@ -1,6 +1,10 @@
 #ifndef _client_h_
 #define _client_h_
 
+#ifdef _MSC_VER
+	#define snprintf _snprintf
+#endif
+
 #define DEFAULT_PORT 4080
 
 void client_enable();


### PR DESCRIPTION
Visual Studio 2013 has C99 support which allows Craft to be built successfully using the MSVC compiler.  The only requirement, besides updating the Cmake file, is that <code>snprintf</code> apparently exists as <code>_snprintf</code> in MSVC's C compiler, so you can just <code>#define</code> it.
