### PR TITLE
Port to run Craft in web browser using Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ endif ()
 
 add_definitions(-std=c99 -O3)
 
+if (EMSCRIPTEN)
+    # Emscripten default is GLFW 2.x but we use GLFW 3.x
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s USE_GLFW=3")
+endif ()
+
 if (NOT EMSCRIPTEN)
     # Emscripten includes its own GLFW and GLEW ports
     add_subdirectory(deps/glfw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,35 @@ project(craft)
 
 FILE(GLOB SOURCE_FILES src/*.c)
 
-add_executable(
-    craft
-    ${SOURCE_FILES}
-    deps/glew/src/glew.c
-    deps/lodepng/lodepng.c
-    deps/noise/noise.c
-    deps/sqlite/sqlite3.c
-    deps/tinycthread/tinycthread.c)
+if (EMSCRIPTEN)
+    add_executable(
+        craft
+        ${SOURCE_FILES}
+        #deps/glew/src/glew.c
+        deps/lodepng/lodepng.c
+        deps/noise/noise.c
+        deps/sqlite/sqlite3.c
+        deps/tinycthread/tinycthread.c)
+else ()
+    add_executable(
+        craft
+        ${SOURCE_FILES}
+        deps/glew/src/glew.c
+        deps/lodepng/lodepng.c
+        deps/noise/noise.c
+        deps/sqlite/sqlite3.c
+        deps/tinycthread/tinycthread.c)
+endif ()
 
 add_definitions(-std=c99 -O3)
 
-add_subdirectory(deps/glfw)
-include_directories(deps/glew/include)
-include_directories(deps/glfw/include)
+if (NOT EMSCRIPTEN)
+    # Emscripten includes its own GLFW and GLEW ports
+    add_subdirectory(deps/glfw)
+    include_directories(deps/glew/include)
+    include_directories(deps/glfw/include)
+endif ()
+
 include_directories(deps/lodepng)
 include_directories(deps/noise)
 include_directories(deps/sqlite)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ endif ()
 add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
-    # Emscripten default is GLFW 2.x but we use GLFW 3.x
-    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3")
+    # Emscripten default is GLFW 2.x but we use GLFW 3.x, also include data files
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3 --embed-file ../shaders/")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
     # Emscripten default is GLFW 2.x but we use GLFW 3.x, also include data files
-    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3 --embed-file ../shaders/")
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3 --embed-file ../shaders/ --embed-file ../textures/")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
     # Emscripten default is GLFW 2.x but we use GLFW 3.x, also include data files
-    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3 --embed-file ../shaders/ --embed-file ../textures/")
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3 --embed-file ../shaders/ -s TOTAL_MEMORY=33554432 --embed-file ../textures/")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,12 @@ if(MINGW)
         "C:/Program Files/CURL/include" "C:/Program Files (x86)/CURL/include")
 endif()
 
-find_package(CURL REQUIRED)
-include_directories(${CURL_INCLUDE_DIR})
+if (NOT EMSCRIPTEN)
+    find_package(CURL REQUIRED)
+    include_directories(${CURL_INCLUDE_DIR})
+else ()
+    set(CURL_LIBRARIES "")
+endif ()
 
 if(APPLE)
     target_link_libraries(craft glfw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(-std=c99 -O3)
 
 if (EMSCRIPTEN)
     # Emscripten default is GLFW 2.x but we use GLFW 3.x
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s USE_GLFW=3")
+    set_target_properties(craft PROPERTIES LINK_FLAGS "-s USE_GLFW=3")
 endif ()
 
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if (EMSCRIPTEN)
         deps/noise/noise.c
         deps/sqlite/sqlite3.c
         deps/tinycthread/tinycthread.c)
+    # Generate HTML file wrapper in addition to .js
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
 else ()
     add_executable(
         craft

--- a/README.md
+++ b/README.md
@@ -59,13 +59,16 @@ terminal.
 
     git clone https://github.com/fogleman/Craft.git
     cd Craft
-    cmake .
+    mkdir build
+    pushd build
+    cmake ..
     make
-    ./craft
+    popd
+    ./build/craft
 
 To build for the web (experimental), install [Emscripten](http://emscripten.org) and instead run:
 
-    cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake .
+    cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake ..
 
 ### Multiplayer
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ terminal.
     make
     ./craft
 
+To build for the web (experimental), install [Emscripten](http://emscripten.org) and instead run:
+
+    cmake -DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake .
+
 ### Multiplayer
 
 Register for an account!

--- a/shaders/block_fragment.glsl
+++ b/shaders/block_fragment.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform sampler2D sampler;
 uniform sampler2D sky_sampler;

--- a/shaders/block_fragment.glsl
+++ b/shaders/block_fragment.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform sampler2D sampler;
 uniform sampler2D sky_sampler;

--- a/shaders/block_fragment.glsl
+++ b/shaders/block_fragment.glsl
@@ -1,5 +1,6 @@
 #ifdef GL_ES
 precision mediump float;
+precision mediump int;
 #endif
 
 uniform sampler2D sampler;

--- a/shaders/block_vertex.glsl
+++ b/shaders/block_vertex.glsl
@@ -1,5 +1,6 @@
 #ifdef GL_ES
 precision mediump float;
+precision mediump int;
 #endif
 
 uniform mat4 matrix;

--- a/shaders/block_vertex.glsl
+++ b/shaders/block_vertex.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform mat4 matrix;
 uniform vec3 camera;

--- a/shaders/block_vertex.glsl
+++ b/shaders/block_vertex.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform mat4 matrix;
 uniform vec3 camera;
@@ -17,7 +17,7 @@ varying float fog_height;
 varying float diffuse;
 
 const float pi = 3.14159265;
-const vec3 light_direction = normalize(vec3(-1.0, 1.0, -1.0));
+vec3 light_direction = normalize(vec3(-1.0, 1.0, -1.0));
 
 void main() {
     gl_Position = matrix * position;
@@ -34,6 +34,6 @@ void main() {
         fog_factor = pow(clamp(camera_distance / fog_distance, 0.0, 1.0), 4.0);
         float dy = position.y - camera.y;
         float dx = distance(position.xz, camera.xz);
-        fog_height = (atan(dy, dx) + pi / 2) / pi;
+        fog_height = (atan(dy, dx) + pi / 2.0) / pi;
     }
 }

--- a/shaders/line_fragment.glsl
+++ b/shaders/line_fragment.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 void main() {
     gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);

--- a/shaders/line_fragment.glsl
+++ b/shaders/line_fragment.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 void main() {
     gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);

--- a/shaders/line_vertex.glsl
+++ b/shaders/line_vertex.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform mat4 matrix;
 

--- a/shaders/line_vertex.glsl
+++ b/shaders/line_vertex.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform mat4 matrix;
 

--- a/shaders/sky_fragment.glsl
+++ b/shaders/sky_fragment.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform sampler2D sampler;
 uniform float timer;

--- a/shaders/sky_fragment.glsl
+++ b/shaders/sky_fragment.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform sampler2D sampler;
 uniform float timer;

--- a/shaders/sky_vertex.glsl
+++ b/shaders/sky_vertex.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform mat4 matrix;
 

--- a/shaders/sky_vertex.glsl
+++ b/shaders/sky_vertex.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform mat4 matrix;
 

--- a/shaders/text_fragment.glsl
+++ b/shaders/text_fragment.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform sampler2D sampler;
 uniform bool is_sign;

--- a/shaders/text_fragment.glsl
+++ b/shaders/text_fragment.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform sampler2D sampler;
 uniform bool is_sign;

--- a/shaders/text_vertex.glsl
+++ b/shaders/text_vertex.glsl
@@ -1,4 +1,6 @@
-
+#ifdef GL_ES
+precision mediump float;
+#endif
 
 uniform mat4 matrix;
 

--- a/shaders/text_vertex.glsl
+++ b/shaders/text_vertex.glsl
@@ -1,4 +1,4 @@
-#version 120
+
 
 uniform mat4 matrix;
 

--- a/src/auth.c
+++ b/src/auth.c
@@ -1,4 +1,6 @@
+#ifndef __EMSCRIPTEN__
 #include <curl/curl.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -21,6 +23,9 @@ size_t write_function(char *data, size_t size, size_t count, void *arg) {
 int get_access_token(
     char *result, int length, char *username, char *identity_token)
 {
+#ifdef __EMSCRIPTEN__
+    return 0;
+#else
     static char url[] = "https://craft.michaelfogleman.com/api/1/identity";
     strncpy(result, "", length);
     CURL *curl = curl_easy_init();
@@ -46,4 +51,5 @@ int get_access_token(
         }
     }
     return 0;
+#endif
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2634,7 +2634,9 @@ int main(int argc, char **argv) {
 
     glEnable(GL_CULL_FACE);
     glEnable(GL_DEPTH_TEST);
+#ifndef __EMSCRIPTEN__ // TODO: remove, what is replacement? glLogicOp not in >=GLES2: https://github.com/kripken/emscripten/issues/1416
     glLogicOp(GL_INVERT);
+#endif
     glClearColor(0, 0, 0, 1);
 
     // LOAD TEXTURES //

--- a/src/main.c
+++ b/src/main.c
@@ -2622,7 +2622,6 @@ int main(int argc, char **argv) {
     }
 
     glfwMakeContextCurrent(g->window);
-    glfwSwapInterval(VSYNC);
     glfwSetInputMode(g->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
     glfwSetKeyCallback(g->window, on_key);
     glfwSetCharCallback(g->window, on_char);
@@ -2794,6 +2793,7 @@ int main(int argc, char **argv) {
 #ifdef __EMSCRIPTEN__
         emscripten_set_main_loop(one_iter, 60, 1);
 #else
+        glfwSwapInterval(VSYNC);
         g_inner_break = 0;
         while (1) {
             one_iter();

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,9 @@
 #ifndef __EMSCRIPTEN__
 #include <curl/curl.h>
 #endif
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2788,11 +2791,15 @@ int main(int argc, char **argv) {
 
         // BEGIN MAIN LOOP //
         previous = glfwGetTime();
+#ifdef __EMSCRIPTEN__
+        emscripten_set_main_loop(one_iter, 60, 1);
+#else
         g_inner_break = 0;
         while (1) {
             one_iter();
             if (g_inner_break) break;
         }
+#endif
 
         // SHUTDOWN //
         db_save_state(s->x, s->y, s->z, s->rx, s->ry);

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,8 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
+#ifndef __EMSCRIPTEN__
 #include <curl/curl.h>
+#endif
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2585,7 +2587,9 @@ void reset_model() {
 
 int main(int argc, char **argv) {
     // INITIALIZATION //
+#ifndef __EMSCRIPTEN__
     curl_global_init(CURL_GLOBAL_DEFAULT);
+#endif
     srand(time(NULL));
     rand();
 
@@ -2958,6 +2962,8 @@ int main(int argc, char **argv) {
     }
 
     glfwTerminate();
+#ifndef __EMSCRIPTEN__
     curl_global_cleanup();
+#endif
     return 0;
 }


### PR DESCRIPTION
Allows building with [emscripten](http://kripken.github.io/emscripten-site/) to target the web browser. A first step, functional but not comprehensively tested functionality. Retains the ability to build natively by default. Screenshot running in browser:

![screen shot 2017-04-02 at 11 12 00 am](https://cloud.githubusercontent.com/assets/26856618/24589821/38f6cb14-1796-11e7-8cb3-99f2f7129cf8.png)
