### PR TITLE
Add missing controls to readme: ctrl, T, /, and `

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ the client.
 - Space to jump.
 - Left Click to destroy a block.
 - Right Click or Cmd + Left Click to create a block.
+- Ctrl + Right Click to toggle a block as a light source.
 - 1-9 to select the block type to create.
 - E to cycle through the block types.
 - Tab to toggle between walking and flying.
@@ -102,6 +103,9 @@ the client.
 - F to show the scene in orthographic mode.
 - O to observe players in the main view.
 - P to observe players in the picture-in-picture view.
+- T to type text into chat.
+- Forward slash (/) to enter a command.
+- Backquote (`) to write text on any block (signs).
 - Arrow keys emulate mouse movement.
 - Enter emulates mouse click.
 


### PR DESCRIPTION
Couldn't find these keystrokes documented anywhere, so I added them to the readme for future reference. 