### PR TITLE
Show error and exit on shader/texture file open failure

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include "lodepng.h"
 #include "matrix.h"
 #include "util.h"
@@ -28,6 +29,10 @@ void update_fps(FPS *fps) {
 
 char *load_file(const char *path) {
     FILE *file = fopen(path, "rb");
+    if (!file) {
+        fprintf(stderr, "fopen %s failed: %d %s\n", path, errno, strerror(errno));
+        exit(1);
+    }
     fseek(file, 0, SEEK_END);
     int length = ftell(file);
     rewind(file);
@@ -134,7 +139,8 @@ void load_png_texture(const char *file_name) {
     unsigned int width, height;
     error = lodepng_decode32_file(&data, &width, &height, file_name);
     if (error) {
-        fprintf(stderr, "error %u: %s\n", error, lodepng_error_text(error));
+        fprintf(stderr, "load_png_texture %s failed, error %u: %s\n", file_name, error, lodepng_error_text(error));
+        exit(1);
     }
     flip_image_vertical(data, width, height);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,


### PR DESCRIPTION
When craft cannot load shader or texture files (for example, if launched outside of its resource directory), it would crash with a segmentation fault:

```
native-build $ ./craft 
error 78: failed to open file for reading
Segmentation fault: 11
```

This PR fixes this crash by exiting with an error, as well as printing the file which failed to load:

```
native-build $ ./craft
load_png_texture textures/texture.png failed, error 78: failed to open file for reading
```