### PR TITLE
Fix placing blocks on plants or other non-obstacles (simple fix)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2154,7 +2154,11 @@ void on_right_click() {
     State *s = &g->players->state;
     int hx, hy, hz;
     int hw = hit_test(1, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
-    if (hy > 0 && hy < 256 && is_obstacle(hw)) {
+    if (hy > 0 && hy < 256) {
+        if (!is_obstacle(hw)) {
+            hw = hit_test(0, s->x, s->y, s->z, s->rx, s->ry, &hx, &hy, &hz);
+        }
+
         if (!player_intersects_block(2, s->x, s->y, s->z, hx, hy, hz)) {
             set_block(hx, hy, hz, items[g->item_index]);
             record_block(hx, hy, hz, items[g->item_index]);


### PR DESCRIPTION
Right-clicking on a non-obstacle block (such as a plant) used to do nothing. I originally suspected it was an issue in hit testing, but turns out to be an easy fix: if the hit target is not an obstacle, then create the new block on the clicked block. This matches the commonly expected behavior e.g. in Minecraft.

Before:

<img width="1236" alt="screen shot 2017-05-07 at 7 52 07 pm" src="https://cloud.githubusercontent.com/assets/26856618/25788555/d4b89e22-335e-11e7-9ed8-df0ce01130cc.png">

After right-click, without this pull request: nothing happens

<img width="1236" alt="screen shot 2017-05-07 at 7 52 07 pm" src="https://cloud.githubusercontent.com/assets/26856618/25788555/d4b89e22-335e-11e7-9ed8-df0ce01130cc.png">

After right-click, with this pull request: 

<img width="1243" alt="screen shot 2017-05-07 at 7 52 14 pm" src="https://cloud.githubusercontent.com/assets/26856618/25788560/e209f1f2-335e-11e7-8ff5-5318545f19db.png">
