### PR TITLE
Remove warnings with gcc 7+

### DIFF
--- a/deps/glfw/src/linux_joystick.c
+++ b/deps/glfw/src/linux_joystick.c
@@ -25,6 +25,10 @@
 //
 //========================================================================
 
+#ifdef __GNUC__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "internal.h"
 
 #if defined(__linux__)

--- a/deps/glfw/src/linux_joystick.c
+++ b/deps/glfw/src/linux_joystick.c
@@ -25,6 +25,7 @@
 //
 //========================================================================
 
+#define _GNU_SOURCE
 #ifdef __GNUC__
 #define _POSIX_C_SOURCE 200809L
 #endif
@@ -234,14 +235,23 @@ int _glfwInitJoysticks(void)
 
         while ((entry = readdir(dir)))
         {
-            char path[20];
+            char* path = NULL;
             regmatch_t match;
 
             if (regexec(&_glfw.linux_js.regex, entry->d_name, 1, &match, 0) != 0)
                 continue;
 
-            snprintf(path, sizeof(path), "%s/%s", dirname, entry->d_name);
+            if (asprintf(&path, "%s/%s", dirname, entry->d_name) < 0)
+            {
+                _glfwInputError(GLFW_PLATFORM_ERROR,
+				"Linux: Failed to construct device path: %s",
+				strerror(errno));
+		continue;
+
+	    }
+
             openJoystickDevice(path);
+	    free(path);
         }
 
         closedir(dir);

--- a/deps/glfw/src/monitor.c
+++ b/deps/glfw/src/monitor.c
@@ -25,6 +25,10 @@
 //
 //========================================================================
 
+#ifdef __GNUC__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "internal.h"
 
 #include <math.h>

--- a/deps/glfw/src/x11_window.c
+++ b/deps/glfw/src/x11_window.c
@@ -25,6 +25,10 @@
 //
 //========================================================================
 
+#ifdef __GNUC__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "internal.h"
 
 #include <X11/cursorfont.h>

--- a/deps/glfw/tests/glfwinfo.c
+++ b/deps/glfw/tests/glfwinfo.c
@@ -34,6 +34,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __GNUC__
+#include <strings.h>
+#endif
 
 #include "getopt.h"
 

--- a/deps/glfw/tests/joysticks.c
+++ b/deps/glfw/tests/joysticks.c
@@ -28,6 +28,10 @@
 //
 //========================================================================
 
+#ifdef __GNUC__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <GLFW/glfw3.h>
 
 #include <stdio.h>


### PR DESCRIPTION
Saw this cool project on Hacker News. Here are some very small patches to eliminate warnings with gcc v7+.