### PR TITLE
Make FOV Configurable #242

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,24 @@ cmake_minimum_required(VERSION 2.8)
 
 project(craft)
 
-FILE(GLOB SOURCE_FILES src/*.c)
+# Not good code
+# FILE(GLOB SOURCE_FILES src/*.c)
+
+# Good code
+set(SOURCE_FILES
+    src/main.c
+    src/auth.c
+    src/client.c
+    src/cube.c
+    src/db.c
+    src/item.c
+    src/map.c
+    src/matrix.c
+    src/ring.c
+    src/sign.c
+    src/util.c
+    src/world.c
+)
 
 add_executable(
     craft

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Craft
+## Craft Reborn
 
-Minecraft clone for Windows, Mac OS X and Linux. Just a few thousand lines of C using modern OpenGL (shaders). Online multiplayer support is included using a Python-based server.
+Minecraft clone for Windows, Mac OS X and Linux. Just a few thousand lines of C using modern OpenGL (shaders). Online multiplayer support is included using a Python-based server. The original Craft project was started in 2013 by Michael Fogleman. However, the latest update to the original was in 2017 and issues have been piling up since. This project is a fork of the original Craft with the idea that the project can continue and new stuff can be added even when the original maintainer has moved on.
 
-http://www.michaelfogleman.com/craft/
+Original website: http://www.michaelfogleman.com/craft/
 
 ![Screenshot](http://i.imgur.com/SH7wcas.png)
 
@@ -65,7 +65,7 @@ terminal.
 
 ### Multiplayer
 
-Register for an account!
+Register for an account! NOTE: Servers may not be available at the current time!
 
 https://craft.michaelfogleman.com/
 

--- a/src/config.h
+++ b/src/config.h
@@ -13,7 +13,7 @@
 #define USE_CACHE 1
 #define DAY_LENGTH 600
 #define INVERT_MOUSE 0
-#define FOVY 85
+#define FOVY 65
 #define FOVY_ZOOM 15
 
 // rendering options

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,8 @@
 #define USE_CACHE 1
 #define DAY_LENGTH 600
 #define INVERT_MOUSE 0
+#define FOVY 85
+#define FOVY_ZOOM 15
 
 // rendering options
 #define SHOW_LIGHTS 1

--- a/src/main.c
+++ b/src/main.c
@@ -2416,7 +2416,7 @@ void handle_movement(double dt) {
     if (!g->typing) {
         float m = dt * 1.0;
         g->ortho = glfwGetKey(g->window, CRAFT_KEY_ORTHO) ? 64 : 0;
-        g->fov = glfwGetKey(g->window, CRAFT_KEY_ZOOM) ? 15 : 65;
+        g->fov = glfwGetKey(g->window, CRAFT_KEY_ZOOM) ? FOVY_ZOOM : FOVY;
         if (glfwGetKey(g->window, CRAFT_KEY_FORWARD)) sz--;
         if (glfwGetKey(g->window, CRAFT_KEY_BACKWARD)) sz++;
         if (glfwGetKey(g->window, CRAFT_KEY_LEFT)) sx--;


### PR DESCRIPTION
FOV is now configurable from `config.h`. There are two preprocessor definitions, `FOVY` is responsible for the normal FOV, and `FOVY_ZOOM` is the FOV when zooming.

This fixes issue #242 