### PR TITLE
Update glfw Debian package to glf3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the installation:
 #### Linux (Ubuntu)
 
     sudo apt-get install cmake libglew-dev xorg-dev libcurl4-openssl-dev
-    sudo apt-get build-dep glfw
+    sudo apt-get build-dep glfw3
 
 #### Windows
 


### PR DESCRIPTION
- In the Linux build documentation the Debian source package
  for glfw is `glfw` but is now `glfw3`
- https://packages.debian.org/source/stable/glfw3